### PR TITLE
Fix argmax call in logreg tutorial docs to include axis=1.

### DIFF
--- a/doc/logreg.txt
+++ b/doc/logreg.txt
@@ -83,7 +83,7 @@ The code to do this in Theano is the following:
 
   # symbolic description of how to compute prediction as class whose probability
   # is maximal
-  y_pred = T.argmax(p_y_given_x)
+  y_pred = T.argmax(p_y_given_x, axis=1)
 
   # compiled theano function that returns this value
   classify = theano.function(inputs=[x], outputs=y_pred)


### PR DESCRIPTION
There is one little error in the text, which led to a very subtle bug, that I just a significant amount of time hunting done. In the first code listing on that page, the second to last code line needs to read:

y_pred = T.argmax(p_y_given_x, axis=1)

instead of 

y_pred = T.argmax(p_y_given_x)

As far as I understand it, these lines used to be equivalent in a previous version of Theano, but now they are different significantly different. (At first glance, the code appears to run just fine, though.)
