### PR TITLE
Fix typo in mlp.txt

### DIFF
--- a/doc/mlp.txt
+++ b/doc/mlp.txt
@@ -289,8 +289,8 @@ The code that computes the new cost is:
     # the model plus the regularization terms (L1 and L2); cost is expressed
     # here symbolically
     cost = classifier.negative_log_likelihood(y) \
-         + L1_reg * L1 \
-         + L2_reg * L2_sqr
+         + L1_reg * classifier.L1 \
+         + L2_reg * classifier.L2_sqr
 
 
 We then update the parameters of the model using the gradient. This code is


### PR DESCRIPTION
The example code to compute the cost of the linear combination of L1 and L2 regularization penalties didn't match the code below.  They referred to variables `L1` and `L2`, which should actually be  `classifier.L1` and `classifier.L2`.
