### PR TITLE
Change equation formatting to code formatting

### DIFF
--- a/doc/SdA.txt
+++ b/doc/SdA.txt
@@ -410,7 +410,7 @@ to the training set for a fixed number of epochs given by
 
 The fine-tuning loop is very similar with the one in the :ref:`mlp`, the
 only difference is that we will use now the functions given by
-`build_finetune_functions`  .
+``build_finetune_functions``  .
 
 
 


### PR DESCRIPTION
`build_finetune_functions` is being rendered as a broken math equation, not a code snippet.

![1735cdfbfbfc569c028c02ee182eb0c6b1e00475](https://f.cloud.github.com/assets/435548/1823495/1b0422da-717e-11e3-975e-c105faddbef5.png)
