### PR TITLE
Alternative to PIL.image for Mac OS X.

### DIFF
--- a/code/cA.py
+++ b/code/cA.py
@@ -42,7 +42,10 @@ import theano.tensor as T
 from logistic_sgd import load_data
 from utils import tile_raster_images
 
-import PIL.Image
+try:
+    import PIL.Image as Image
+except ImportError:
+    import Image
 
 
 class cA(object):
@@ -290,7 +293,7 @@ def test_cA(learning_rate=0.01, training_epochs=20,
 
     print >> sys.stderr, ('The code for file ' + os.path.split(__file__)[1] +
                           ' ran for %.2fm' % ((training_time) / 60.))
-    image = PIL.Image.fromarray(tile_raster_images(
+    image = Image.fromarray(tile_raster_images(
         X=ca.W.get_value(borrow=True).T,
         img_shape=(28, 28), tile_shape=(10, 10),
         tile_spacing=(1, 1)))

--- a/code/dA.py
+++ b/code/dA.py
@@ -45,7 +45,10 @@ from theano.tensor.shared_randomstreams import RandomStreams
 from logistic_sgd import load_data
 from utils import tile_raster_images
 
-import PIL.Image
+try:
+    import PIL.Image as Image
+except ImportError:
+    import Image
 
 
 class dA(object):
@@ -306,7 +309,7 @@ def test_dA(learning_rate=0.1, training_epochs=15,
     print >> sys.stderr, ('The no corruption code for file ' +
                           os.path.split(__file__)[1] +
                           ' ran for %.2fm' % ((training_time) / 60.))
-    image = PIL.Image.fromarray(
+    image = Image.fromarray(
         tile_raster_images(X=da.W.get_value(borrow=True).T,
                            img_shape=(28, 28), tile_shape=(10, 10),
                            tile_spacing=(1, 1)))
@@ -352,7 +355,7 @@ def test_dA(learning_rate=0.1, training_epochs=15,
                           os.path.split(__file__)[1] +
                           ' ran for %.2fm' % (training_time / 60.))
 
-    image = PIL.Image.fromarray(tile_raster_images(
+    image = Image.fromarray(tile_raster_images(
         X=da.W.get_value(borrow=True).T,
         img_shape=(28, 28), tile_shape=(10, 10),
         tile_spacing=(1, 1)))

--- a/code/rbm.py
+++ b/code/rbm.py
@@ -7,7 +7,11 @@ to those without visible-visible and hidden-hidden connections.
 import cPickle
 import gzip
 import time
-import PIL.Image
+
+try:
+    import PIL.Image as Image
+except ImportError:
+    import Image
 
 import numpy
 
@@ -396,7 +400,7 @@ def test_rbm(learning_rate=0.1, training_epochs=15,
         # Plot filters after each training epoch
         plotting_start = time.clock()
         # Construct image from the weight matrix
-        image = PIL.Image.fromarray(tile_raster_images(
+        image = Image.fromarray(tile_raster_images(
                  X=rbm.W.get_value(borrow=True).T,
                  img_shape=(28, 28), tile_shape=(10, 10),
                  tile_spacing=(1, 1)))
@@ -459,7 +463,7 @@ def test_rbm(learning_rate=0.1, training_epochs=15,
                 tile_spacing=(1, 1))
         # construct image
 
-    image = PIL.Image.fromarray(image_data)
+    image = Image.fromarray(image_data)
     image.save('samples.png')
     os.chdir('../')
 

--- a/code/utils.py
+++ b/code/utils.py
@@ -47,7 +47,7 @@ def tile_raster_images(X, img_shape, tile_shape, tile_spacing=(0, 0),
 
 
     :returns: array suitable for viewing as an image.
-    (See:`PIL.Image.fromarray`.)
+    (See:`Image.fromarray`.)
     :rtype: a 2-d array with same dtype as X.
 
     """

--- a/doc/dA.txt
+++ b/doc/dA.txt
@@ -588,7 +588,7 @@ save the filters as an image :
 
 .. code-block:: python
 
-    image = PIL.Image.fromarray(tile_raster_images(X=da.W.get_value(borrow=True).T,
+    image = Image.fromarray(tile_raster_images(X=da.W.get_value(borrow=True).T,
                  img_shape=(28, 28), tile_shape=(10, 10),
                  tile_spacing=(1, 1)))
     image.save('filters_corruption_30.png')

--- a/doc/rbm.txt
+++ b/doc/rbm.txt
@@ -754,7 +754,7 @@ been shown to lead to a better generative model ([Tieleman08]_).
         # Plot filters after each training epoch
         plotting_start = time.clock()
         # Construct image from the weight matrix
-        image = PIL.Image.fromarray(tile_raster_images(
+        image = Image.fromarray(tile_raster_images(
                  X=rbm.W.get_value(borrow=True).T,
                  img_shape=(28, 28), tile_shape=(10, 10),
                  tile_spacing=(1, 1)))
@@ -841,7 +841,7 @@ samples at every 1000 steps.
                 tile_spacing=(1, 1))
         # construct image
 
-    image = PIL.Image.fromarray(image_data)
+    image = Image.fromarray(image_data)
     print ' ... plotting sample ', idx
     image.save('samples.png')
 

--- a/doc/utilities.txt
+++ b/doc/utilities.txt
@@ -78,7 +78,7 @@ Tiling minibatches together is done for us by the
 
 
     :returns: array suitable for viewing as an image.
-    (See:`PIL.Image.fromarray`.)
+    (See:`Image.fromarray`.)
     :rtype: a 2-d array with same dtype as X.
 
     """


### PR DESCRIPTION
On some systems Image must be imported instead of PIL.Image.

http://stackoverflow.com/questions/8863917/importerror-no-module-named-pil
