### PR TITLE
early stop kicks in only after patience+1 validation runs

### DIFF
--- a/code/lstm.py
+++ b/code/lstm.py
@@ -558,7 +558,7 @@ def train(dim_proj=100,
 
                     best_p = unzip(tparams)
                     bad_counter = 0
-                if (len(history_errs) > patience and 
+                if (len(history_errs) > patience and
                     valid_err >= numpy.array(history_errs)[:-patience,
                                                            0].min()):
                     bad_counter += 1


### PR DESCRIPTION
This part of the code was assuming that validFreq is either -1 or the number of training batches. This simply guarantees that the early-stopping will kick in only once at least patience number of validation runs were made.
