### PR TITLE
title fixed

### DIFF
--- a/doc/lstm.txt
+++ b/doc/lstm.txt
@@ -1,6 +1,6 @@
 .. _lstm:
 
-Recurrent Neural Networks with Word Embeddings
+LSTM Network for Sentiment Analysis
 **********************************************
 
 Summary


### PR DESCRIPTION
The title of the LSTM tutorial was incorrectly set to the title of another RNN tutorial.