### PR TITLE
Fixes in LSTM tutorial

### DIFF
--- a/doc/lstm.txt
+++ b/doc/lstm.txt
@@ -235,8 +235,9 @@ Thank you!
 Contact
 =======
 
-Please email `Kyunghyun Cho <http://www.kyunghyuncho.me/>`_ for any
-problem report or feedback. We will be glad to hear from you.
+Please email `Pierre Luc Carrier <mailto:carriepl..at..iro.umontreal.ca>`_ or
+`Kyunghyun Cho <http://www.kyunghyuncho.me/>`_ for any problem report or
+feedback. We will be glad to hear from you.
 
 References
 ++++++++++

--- a/doc/lstm.txt
+++ b/doc/lstm.txt
@@ -124,7 +124,7 @@ output gates and, subsequently, their outputs :
 .. math::
     :label: 5
 
-    o_t = \sigma(W_o x_t + U_o h_{t-1} + V_o C_t + b_1)
+    o_t = \sigma(W_o x_t + U_o h_{t-1} + V_o C_t + b_o)
 
 .. math::
     :label: 6
@@ -144,7 +144,7 @@ matrix :math:`V_o` and equation :eq:`5` is replaced by equation :eq:`5-alt` :
 .. math::
     :label: 5-alt
 
-    o_t = \sigma(W_o x_t + U_o h_{t-1} + b_1)
+    o_t = \sigma(W_o x_t + U_o h_{t-1} + b_o)
 
 Our model is composed of a single LSTM layer followed by an average pooling
 and a logistic regression layer as illustrated in Figure 2 below. Thus, from


### PR DESCRIPTION
This fixes typos in two equations of the LSTM tutorial.
It also add my name as a support person since I'm the one who wrote the tutorial and the other support person is currently not available to update this tutorial if needed.