### PR TITLE
Fix protocol usage for cloning GitHub's repository

### DIFF
--- a/doc/gettingstarted.txt
+++ b/doc/gettingstarted.txt
@@ -20,7 +20,7 @@ Download
 
 On each learning algorithm page, you will be able to download the corresponding files. If you want to download all of them at the same time, you can clone the git repository of the tutorial::
 
-    git clone git://github.com/lisa-lab/DeepLearningTutorials.git
+    git clone https://github.com/lisa-lab/DeepLearningTutorials.git
 
 
 .. _datasets:

--- a/doc/gettingstarted.txt
+++ b/doc/gettingstarted.txt
@@ -96,7 +96,7 @@ MNIST Dataset
  memory and therefore bypassing the overhead.
  Because the datapoints and their labels are usually of different nature
  (labels are usually integers while datapoints are real numbers) we
- suggest to use different variables for labes and data. Also we recomand
+ suggest to use different variables for label and data. Also we recommend
  using different variables for the training set, validation set and
  testing set to make the code more readable (resulting in 6 different
  shared variables).


### PR DESCRIPTION
Output on my machine:

$ git clone git://github.com/lisa-lab/DeepLearningTutorials.git
Cloning into 'DeepLearningTutorials'...
fatal: unable to connect to github.com:
github.com[0: 192.30.252.128]: errno=Connection refused

However:

$ git clone https://github.com/lisa-lab/DeepLearningTutorials.git
Cloning into 'DeepLearningTutorials'...
remote: Counting objects: 3652, done.
remote: Total 3652 (delta 0), reused 0 (delta 0), pack-reused 3652
Receiving objects: 100% (3652/3652), 7.80 MiB | 1.77 MiB/s, done.
Resolving deltas: 100% (2161/2161), done.
Checking connectivity... done.

I just used the GitHub's clone URL (default protocol is https)