### PR TITLE
greetingstxt pull request

### DIFF
--- a/doc/gettingstarted.txt
+++ b/doc/gettingstarted.txt
@@ -525,7 +525,7 @@ L2 regularization term weighted by :math:`\lambda_2`
   L1  = T.sum(abs(param))
 
   # symbolic Theano variable that represents the squared L2 term
-  L2_sqr = T.sum(param ** 2)
+  L2 = T.sum(param ** 2)
 
   # the loss
   loss = NLL + lambda_1 * L1 + lambda_2 * L2


### PR DESCRIPTION
At L1 and L2 regularization topic loss function and L2 variable is not same. Loss function variable must be L2_sqr or L2_sqr must be L2 to match with loss function. This request changes L2_sqr to L2 for matching loss function.