### PR TITLE
add explicit CUDA path to buildbot

### DIFF
--- a/.jenkins/jenkins_buildbot_dlt.sh
+++ b/.jenkins/jenkins_buildbot_dlt.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
+# CUDA
+export PATH=/usr/local/cuda/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+export LIBRARY_PATH=/usr/local/cuda/lib64:$LIBRARY_PATH
+
 BUILDBOT_DIR=$WORKSPACE/nightly_build
-source $HOME/.bashrc
 
 mkdir -p ${BUILDBOT_DIR}
 


### PR DESCRIPTION
With Ubuntu 16, jenkins no longer seems to source the bashrc properly for CUDA paths.