### PR TITLE
Do the speed test on the new gpu back-end.

### DIFF
--- a/code/test.py
+++ b/code/test.py
@@ -190,9 +190,9 @@ def speed():
                 float64_times / float32_times), file=sys.stderr)
 
     #test in float32 in FAST_RUN mode on the gpu
-    import theano.sandbox.cuda
+    import theano.gpuarray
     if do_gpu:
-        theano.sandbox.cuda.use('gpu')
+        theano.gpuarray.use('cuda')
         gpu_times = do_tests()
         times_dic['gpu'] = gpu_times
         test_total += numpy.size(gpu_times)


### PR DESCRIPTION
We need to wait for https://github.com/Theano/Theano/pull/5407 to be merged before mering this PR.

I locally ran the test and it work well:


```
$ nosetests test.py:speed
.../anaconda/lib/python2.7/site-packages/skcuda/cublas.py:273: UserWarning: creating CUBLAS context to get version number
  warnings.warn('creating CUBLAS context to get version number')
Using cuDNN version 5103 on context None
Mapped name None to device cuda: GeForce GTX 750 (0000:05:00.0)
The code for file logistic_sgd.pyc ran for 3.2s
The code for file logistic_cg.pyc ran for 3.8s
The code for file mlp.pyc ran for 0.18m
.../repos/DeepLearningTutorials/code/convolutional_mlp.py:104: UserWarning: DEPRECATION: the 'ds' parameter is not going to exist anymore as it is going to be replaced by the parameter 'ws'.
  ignore_border=True
The code for file convolutional_mlp.pyc ran for 0.10m
The no corruption code for file dA.pyc ran for 0.05m
The 30% corruption code for file dA.pyc ran for 0.05m
The pretraining code for file SdA.pyc ran for 0.04m
The training code for file SdA.pyc ran for 0.04m
WARNING (theano.configdefaults): install mkl with `conda install mkl-service`: No module named mkl
The pretraining code for file DBN.pyc ran for 0.06m
The fine tuning code for file DBN.pyc ran for 0.04m
WARNING (theano.gof.cmodule): A module that was loaded by this ModuleCache can no longer be read from file .../theano.NOBACKUP/compiledir_Linux-3.16--amd64-x86_64-with-debian-8.6--2.7.12-64/tmpRiLZVT/23b1fd8f41b26be52c0c77ff92d2c364.so... this could lead to problems.
Training took 3.4s
['logistic_sgd', 'logistic_cg', 'mlp', 'convolutional_mlp', 'dA', 'SdA', 'DBN', 'rbm', 'rnnrbm', 'rnnslu', 'lstm']
gpu times [  2.73707032   3.7258532   10.73662472   5.73185563   6.36838317
   4.94786191   5.85787058   4.26474953  22.4863615   10.84645605
   5.23835015]
.
----------------------------------------------------------------------
Ran 1 test in 510.563s

OK
```