### PR TITLE
Update rnnrbm.py

### DIFF
--- a/code/rnnrbm.py
+++ b/code/rnnrbm.py
@@ -288,7 +288,8 @@ class RnnRbm:
 
 def test_rnnrbm(batch_size=100, num_epochs=200):
     model = RnnRbm()
-    re = os.path.join(os.path.split(os.path.dirname(__file__))[0],
+    cwd = os.path.dirname(os.path.abspath(__file__))
+    re = os.path.join(os.path.split(cwd)[0],
                       'data', 'Nottingham', 'train', '*.mid')
     model.train(glob.glob(re),
                 batch_size=batch_size, num_epochs=num_epochs)


### PR DESCRIPTION
Hi, so I ran into this error at line 244, then I traced back the error it was due to at line 291, os.path.dirname(__file__) returned empty string and caused the split-out parent directory to be empty, thus the path argument passed into train() function became ./data/Nottingham/train/*.mid which did not exist rather than ../data/Nottingham/train/* which was expected.
So I changed os.path.dirname(__file__) into os.path.dirname(os.path.abspath(__file__)) to get the current working directory from file's absolute path, by which you could then split out the parent directory.
You can refer the reason to this link: https://stackoverflow.com/questions/7783308/os-path-dirname-file-returns-empty